### PR TITLE
Fix pack format of HTTP_X_NGX_OMNIAUTH_INFO

### DIFF
--- a/example/test_backend.rb
+++ b/example/test_backend.rb
@@ -7,7 +7,7 @@ get '/' do
   {
     provider: request.env['HTTP_X_NGX_OMNIAUTH_PROVIDER'],
     user: request.env['HTTP_X_NGX_OMNIAUTH_USER'],
-    info: JSON.parse(request.env['HTTP_X_NGX_OMNIAUTH_INFO'].unpack('m*')[0]),
+    info: JSON.parse(request.env['HTTP_X_NGX_OMNIAUTH_INFO'].unpack('m0')[0]),
   }.to_json
 end
 

--- a/lib/nginx_omniauth_adapter/app.rb
+++ b/lib/nginx_omniauth_adapter/app.rb
@@ -259,7 +259,7 @@ module NginxOmniauthAdapter
       headers(
         'x-ngx-omniauth-provider' => current_user[:provider],
         'x-ngx-omniauth-user' => current_user[:uid],
-        'x-ngx-omniauth-info' => [current_user[:info].to_json].pack('m*'),
+        'x-ngx-omniauth-info' => [current_user[:info].to_json].pack('m0'),
       )
 
       content_type :text


### PR DESCRIPTION
strings in HTTP_X_NGX_OMNIAUTH_INFO were truncated at 60 characters.
A newline code every 60 octeds cause this truncation, so change it to m0 instead of m.

```
HTTP_X_NGX_OMNIAUTH_INFO: eyJuYW1lIjoiSWNoaW5hcmkgU2F0byIsImVtYWlsIjoiaWNoaW5hcmktc2F0
HTTP_X_NGX_OMNIAUTH_INFO unpack: ["{\"name\":\"Ichinari Sato\",\"email\":\"ichinari-sat"]
```
