### PR TITLE
Replace xip.io with nip.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ cd example/
 $ foreman start
 ```
 
-http://ngx-auth-test.127.0.0.1.xip.io:18080/
+http://ngx-auth-test.127.0.0.1.nip.io:18080/
 
 (make sure to have nginx on your PATH)
 

--- a/example/Procfile
+++ b/example/Procfile
@@ -1,3 +1,3 @@
 nginx: nginx -c `pwd`/nginx.conf
-adapter: bundle exec env RACK_ENV=development NGX_OMNIAUTH_HOST=http://ngx-auth.127.0.0.1.xip.io:18080 rackup -p 18081 -o 127.0.0.1 ../config.ru
+adapter: bundle exec env RACK_ENV=development NGX_OMNIAUTH_HOST=http://ngx-auth.127.0.0.1.nip.io:18080 rackup -p 18081 -o 127.0.0.1 ../config.ru
 app: bundle exec ruby test_backend.rb -p 18082 -o 127.0.0.1

--- a/example/nginx-site.conf
+++ b/example/nginx-site.conf
@@ -6,7 +6,7 @@ upstream auth_adapter {
 }
 server {
   listen 127.0.0.1:18080;
-  server_name ngx-auth.127.0.0.1.xip.io;
+  server_name ngx-auth.127.0.0.1.nip.io;
 
   location / {
     proxy_pass http://auth_adapter;
@@ -20,7 +20,7 @@ upstream app {
 }
 server {
   listen 127.0.0.1:18080;
-  server_name ngx-auth-test.127.0.0.1.xip.io;
+  server_name ngx-auth-test.127.0.0.1.nip.io;
 
   # Restricted area
   location / {

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -22,13 +22,13 @@ describe "nginx_omniauth_helper integration" do
       adapter_pid = spawn(
         'docker', 'run',
         '--env', 'RACK_ENV=test',
-        '--env', 'NGX_OMNIAUTH_HOST=http://ngx-auth.127.0.0.1.xip.io:18080',
+        '--env', 'NGX_OMNIAUTH_HOST=http://ngx-auth.127.0.0.1.nip.io:18080',
         '-p', '18081:8080',
         ENV['ADAPTER_DOCKER'],
         out: spec_log, err: spec_log
       )
     else
-      adapter_pid = spawn({'NGX_OMNIAUTH_HOST' => 'http://ngx-auth.127.0.0.1.xip.io:18080'}, 'rackup', '-p', '18081', '-o', '127.0.0.1', File.join(__dir__, '..', 'config.ru'), out: spec_log, err: spec_log)
+      adapter_pid = spawn({'NGX_OMNIAUTH_HOST' => 'http://ngx-auth.127.0.0.1.nip.io:18080'}, 'rackup', '-p', '18081', '-o', '127.0.0.1', File.join(__dir__, '..', 'config.ru'), out: spec_log, err: spec_log)
     end
 
     100.times do
@@ -68,6 +68,6 @@ describe "nginx_omniauth_helper integration" do
   let(:agent) { Mechanize.new }
 
   it "can log in" do
-    expect(agent.get('http://ngx-auth-test.127.0.0.1.xip.io:18080/').body).to include('"42"')
+    expect(agent.get('http://ngx-auth-test.127.0.0.1.nip.io:18080/').body).to include('"42"')
   end
 end


### PR DESCRIPTION
nip.io seems to be a good replacement of xip.io, which is out of
service.