### PR TITLE
Allow configuration of multiple providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Then write `config.ru` then deploy it. (see ./config.ru for example)
 environment variable is available only on included config.ru (or Docker image).
 
 - `:providers`: omniauth provider names.
+- `:provider_desired_http_header` `$NGX_OMNIAUTH_PROVIDER_DESIRED_HTTP_HEADER` (string): Name of HTTP header to specify desired OmniAuth provider (see below). Defaults to 'x-ngx-omniauth-provider-desired`.
 - `:secret` `$NGX_OMNIAUTH_SESSION_SECRET`: Rack session secret. Should be set when not on dev mode
 - `:host` `$NGX_OMNIAUTH_HOST`: URL of adapter. This is used for redirection. Should include protocol (e.g. `http://example.com`.)
   - If this is not specified, adapter will perform redirect using given `Host` header.
@@ -61,6 +62,11 @@ environment variable is available only on included config.ru (or Docker image).
 - `:allowed_back_to_url` `$NGX_OMNIAUTH_ALLOWED_BACK_TO_URL` (regexp): If specified, URL only matches to this are allowed for back_to url.
 - `:app_refresh_interval` `NGX_OMNIAUTH_APP_REFRESH_INTERVAL` (integer): Interval to require refresh session cookie on app domain (in second, default 1 day).
 - `:adapter_refresh_interval` `NGX_OMNIAUTH_ADAPTER_REFRESH_INTERVAL` (integer): Interval to require re-logging in on adapter domain (in second, default 3 days).
+
+### Working with multiple OmniAuth providers
+
+When multiple providers are passed to `:providers`, nginx_omniauth_adapter defaults to the first one in list.
+Other providers in list will only be activated for requests with `x-ngx-omniauth-provider-desired` header (key is configurable via `:provider_desired_http_header`).
 
 ### Included config.ru (or Docker)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Then write `config.ru` then deploy it. (see ./config.ru for example)
 environment variable is available only on included config.ru (or Docker image).
 
 - `:providers`: omniauth provider names.
-- `:provider_desired_http_header` `$NGX_OMNIAUTH_PROVIDER_DESIRED_HTTP_HEADER` (string): Name of HTTP header to specify desired OmniAuth provider (see below). Defaults to 'x-ngx-omniauth-provider-desired`.
+- `:provider_http_header` `$NGX_OMNIAUTH_PROVIDER_HTTP_HEADER` (string): Name of HTTP header to specify OmniAuth provider to be used (see below). Defaults to 'x-ngx-omniauth-provider`.
 - `:secret` `$NGX_OMNIAUTH_SESSION_SECRET`: Rack session secret. Should be set when not on dev mode
 - `:host` `$NGX_OMNIAUTH_HOST`: URL of adapter. This is used for redirection. Should include protocol (e.g. `http://example.com`.)
   - If this is not specified, adapter will perform redirect using given `Host` header.
@@ -66,7 +66,7 @@ environment variable is available only on included config.ru (or Docker image).
 ### Working with multiple OmniAuth providers
 
 When multiple providers are passed to `:providers`, nginx_omniauth_adapter defaults to the first one in list.
-Other providers in list will only be activated for requests with `x-ngx-omniauth-provider-desired` header (key is configurable via `:provider_desired_http_header`).
+Other providers in list will only be activated for requests with `x-ngx-omniauth-provider` header (key is configurable via `:provider_http_header`).
 
 ### Included config.ru (or Docker)
 

--- a/config.ru
+++ b/config.ru
@@ -74,6 +74,7 @@ end
 
 run NginxOmniauthAdapter.app(
   providers: providers,
+  provider_desired_http_header: ENV['NGX_OMNIAUTH_PROVIDER_DESIRED_HTTP_HEADER'] || 'x-ngx-omniauth-provider-desired',
   secret: ENV['NGX_OMNIAUTH_SECRET'],
   host: ENV['NGX_OMNIAUTH_HOST'],
   allowed_app_callback_url: allowed_app_callback_url,

--- a/config.ru
+++ b/config.ru
@@ -74,7 +74,7 @@ end
 
 run NginxOmniauthAdapter.app(
   providers: providers,
-  provider_desired_http_header: ENV['NGX_OMNIAUTH_PROVIDER_DESIRED_HTTP_HEADER'] || 'x-ngx-omniauth-provider-desired',
+  provider_http_header: ENV['NGX_OMNIAUTH_PROVIDER_HTTP_HEADER'] || 'x-ngx-omniauth-provider',
   secret: ENV['NGX_OMNIAUTH_SECRET'],
   host: ENV['NGX_OMNIAUTH_HOST'],
   allowed_app_callback_url: allowed_app_callback_url,

--- a/lib/nginx_omniauth_adapter/app.rb
+++ b/lib/nginx_omniauth_adapter/app.rb
@@ -45,6 +45,10 @@ module NginxOmniauthAdapter
         adapter_config[:providers]
       end
 
+      def provider_desired_http_header
+        adapter_config[:provider_desired_http_header] || 'x-ngx-omniauth-provider-desired'
+      end
+
       def allowed_back_to_url
         adapter_config[:allowed_back_to_url] || /./
       end
@@ -283,7 +287,14 @@ module NginxOmniauthAdapter
     get '/auth' do
       set_flow_id!
 
-      # TODO: choose provider
+      provider_desired = request.env["HTTP_#{provider_desired_http_header.gsub('-', '_').upcase}"]
+      if provider_desired && providers.include?(provider_desired.to_sym)
+        provider = provider_desired
+      else
+        # default to the first provider in list
+        provider = providers[0]
+      end
+
       session[:back_to] = sanitized_back_to_param
       session[:app_callback] = sanitized_app_callback_param
 
@@ -296,8 +307,8 @@ module NginxOmniauthAdapter
         log(message: 'auth_refresh_app', back_to: params[:back_to], callback: params[:callback])
         update_session!
       else
-        log(message: 'auth', provider: providers[0], back_to: params[:back_to], callback: params[:callback])
-        redirect "#{adapter_host}/auth/#{providers[0]}"
+        log(message: 'auth', provider: provider, back_to: params[:back_to], callback: params[:callback])
+        redirect "#{adapter_host}/auth/#{provider}"
       end
     end
 

--- a/lib/nginx_omniauth_adapter/app.rb
+++ b/lib/nginx_omniauth_adapter/app.rb
@@ -45,8 +45,8 @@ module NginxOmniauthAdapter
         adapter_config[:providers]
       end
 
-      def provider_desired_http_header
-        adapter_config[:provider_desired_http_header] || 'x-ngx-omniauth-provider-desired'
+      def provider_http_header
+        adapter_config[:provider_http_header] || 'x-ngx-omniauth-provider'
       end
 
       def allowed_back_to_url
@@ -287,9 +287,13 @@ module NginxOmniauthAdapter
     get '/auth' do
       set_flow_id!
 
-      provider_desired = request.env["HTTP_#{provider_desired_http_header.gsub('-', '_').upcase}"]
-      if provider_desired && providers.include?(provider_desired.to_sym)
-        provider = provider_desired
+      provider_requested = request.env["HTTP_#{provider_http_header.gsub('-', '_').upcase}"]
+      if provider_requested
+        if providers.include?(provider_requested.to_sym)
+          provider = provider_requested.to_sym
+        else
+          halt 401, {'Content-Type' => 'text/plain'}, 'requested provider not available'
+        end
       else
         # default to the first provider in list
         provider = providers[0]


### PR DESCRIPTION
This patch allows multiple providers to be passed to :providers.
The first provider will be used by default (which is the same as
the current behavior).
Requests wishing to be authenticated by other providers must set the
x-ngx-omniauth-provider HTTP header (which is useful in API accesses).