### PR TITLE
Allow omniauth gem v2

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,10 +1,17 @@
 require 'nginx_omniauth_adapter'
 require 'omniauth'
+require 'omniauth/version'
 require 'open-uri'
 require 'json'
 
 dev = ENV['NGX_OMNIAUTH_DEV'] == '1' || ENV['RACK_ENV'] == 'development'
 test = ENV['RACK_ENV'] == 'test'
+
+# We intentionally allow GET for login, knowing CVE-2015-9284.
+OmniAuth.config.allowed_request_methods = [:get, :post]
+if Gem::Version.new(OmniAuth::VERSION) >= Gem::Version.new("2.0.0")
+  OmniAuth.config.silence_get_warning = true
+end
 
 if test
   dev = true

--- a/nginx_omniauth_adapter.gemspec
+++ b/nginx_omniauth_adapter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "sinatra"
-  spec.add_dependency "omniauth", '< 2'
+  spec.add_dependency "omniauth", '< 3'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
For Ruby 3 support, I want to upgrade omniauth gem to v2. (Especially, I want this commit: <https://github.com/omniauth/omniauth/commit/928e7e5672dace6fc8fceb41cc7504edcd77c49f>)

This change still allows GET requests to login, because I believe the current use cases of nginx_omniauth_adapter are tolerant of CVE-2015-9284.