### PR TITLE
Replace deprecated bundle install --path with bundle config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ruby-version }}
       - uses: actions/checkout@v3
       - run: 'apt-get update && apt-get install -y --no-install-recommends nginx'
-      - run: 'bundle install --path ~/bundle'
+      - run: 'bundle config set --local path ~/bundle'
+      - run: 'bundle install'
       - run: 'bundle exec rspec -fd'
 
         #docker-build:


### PR DESCRIPTION
Follow up #6

Bundler 4.0 removed the `--path` flag, breaking the Ruby 4.0 CI job.
Split the step into `bundle config set --local path` and `bundle install`, which works on both bundler 2.x (Ruby 3.2-3.4) and 4.x (Ruby 4.0).